### PR TITLE
Revert "fix(deps): update all dotnet-version patches"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.302",
+    "version": "8.0.301",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Apparently, renovate bot was allowed to merge despite a required check not going through. Hopefully a one time off