### PR TITLE
use secret parameter

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.READ_PACKAGE_PAT }}
+          password: ${{ secrets.PAT }}
 
       - name: Checkout trifork/cheetah-development-infrastructure
         uses: actions/checkout@v4


### PR DESCRIPTION
a workflow was using READ_PACKAGE_PAT directly, but had a PAT parameter secret.
maybe we need to use that instead?

but why does the "PAT" description say "A personal access token with permission to publish a package and push to all branches" when we are passing it the  READ_PACKAGE_PAT?